### PR TITLE
Fix(provider): update `fc2hub` domain

### DIFF
--- a/provider/fc2hub/fc2hub.go
+++ b/provider/fc2hub/fc2hub.go
@@ -29,9 +29,9 @@ const (
 )
 
 const (
-	baseURL   = "https://fc2hub.com/"
-	movieURL  = "https://fc2hub.com/video/%s/id%s/%s"
-	searchURL = "https://fc2hub.com/search?kw=%s"
+	baseURL   = "https://javten.com/"
+	movieURL  = "https://javten.com/video/%s/id%s/%s"
+	searchURL = "https://javten.com/search?kw=%s"
 )
 
 type FC2HUB struct {


### PR DESCRIPTION
因为fc2hub更新了域名，所以在搜索时进行了2次重定向。
第一次重定向到了javten/search路径（新域名），第二次才重定向到最终页面。
我不是很清楚代码的原理，但是在调试过程中，发现url.path为/search，并非最终video页面。