### PR TITLE
add custom translate config for deepl and openai

### DIFF
--- a/translate/deeplx/deeplx.go
+++ b/translate/deeplx/deeplx.go
@@ -1,7 +1,10 @@
 package deeplx
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -21,33 +24,59 @@ func (dpl *DeepLX) Translate(q, source, target string) (result string, err error
 		return "", translate.ErrInvalidConfiguration
 	}
 
-	var resp *http.Response
-	if resp, err = fetch.Post(
-		dpl.BaseURL,
-		fetch.WithURLEncodedBody(map[string]string{
-			"text":            q,
-			"source_lang":     parseToDeeplSupportedLanguage(source),
-			"target_lang":     parseToDeeplSupportedLanguage(target),
-			"split_sentences": "0", // disable sentence split
-		}),
+	// 如果源语言为空，设置为 auto
+	if source == "" {
+		source = "auto"
+	}
+
+	reqBody := map[string]string{
+		"text":        q,
+		"source_lang": parseToDeeplSupportedLanguage(source),
+		"target_lang": parseToDeeplSupportedLanguage(target),
+	}
+
+	// 准备请求选项
+	opts := []fetch.Option{
 		fetch.WithRaiseForStatus(true),
-		fetch.WithHeader("Authorization", "DeepL-Auth-Key "+dpl.APIKey),
-	); err != nil {
-		return
+		fetch.WithHeader("Content-Type", "application/json"),
+		fetch.WithHeader("Accept", "*/*"),
+		fetch.WithHeader("User-Agent", "MetaTube/1.0.0"),
+		fetch.WithHeader("Connection", "keep-alive"),
+	}
+
+	// 如果配置了 API Key，添加认证头
+	if dpl.APIKey != "" {
+		opts = append(opts,
+			fetch.WithHeader("Authorization", "DeepL-Auth-Key "+dpl.APIKey),
+		)
+	}
+
+	var resp *http.Response
+	if resp, err = fetch.Post(dpl.BaseURL, fetch.WithJSONBody(reqBody), opts...); err != nil {
+		return "", fmt.Errorf("request failed: %v", err)
 	}
 	defer resp.Body.Close()
+
+	// 读取响应内容
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %v", err)
+	}
+	fmt.Printf("Response: %s\n", string(respBody))
 
 	var data struct {
 		Code   int    `json:"code"`
 		Data   string `json:"data"`
 		Method string `json:"method"`
 	}
-	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return
+	if err = json.NewDecoder(bytes.NewReader(respBody)).Decode(&data); err != nil {
+		return "", fmt.Errorf("failed to decode response: %v, body: %s", err, string(respBody))
 	}
 
 	if data.Code == 200 {
 		result = data.Data
+	} else {
+		err = fmt.Errorf("translation failed with code %d: %s", data.Code, data.Data)
 	}
 	return
 }

--- a/translate/deeplx/deeplx.go
+++ b/translate/deeplx/deeplx.go
@@ -1,0 +1,72 @@
+package deeplx
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/metatube-community/metatube-sdk-go/common/fetch"
+	"github.com/metatube-community/metatube-sdk-go/translate"
+)
+
+var _ translate.Translator = (*DeepLX)(nil)
+
+type DeepLX struct {
+	APIKey  string `json:"deepl-api-key"`
+	BaseURL string `json:"base-url"`
+}
+
+func (dpl *DeepLX) Translate(q, source, target string) (result string, err error) {
+	if dpl.BaseURL == "" {
+		return "", translate.ErrInvalidConfiguration
+	}
+
+	var resp *http.Response
+	if resp, err = fetch.Post(
+		dpl.BaseURL,
+		fetch.WithURLEncodedBody(map[string]string{
+			"text":            q,
+			"source_lang":     parseToDeeplSupportedLanguage(source),
+			"target_lang":     parseToDeeplSupportedLanguage(target),
+			"split_sentences": "0", // disable sentence split
+		}),
+		fetch.WithRaiseForStatus(true),
+		fetch.WithHeader("Authorization", "DeepL-Auth-Key "+dpl.APIKey),
+	); err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	var data struct {
+		Code   int    `json:"code"`
+		Data   string `json:"data"`
+		Method string `json:"method"`
+	}
+	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return
+	}
+
+	if data.Code == 200 {
+		result = data.Data
+	}
+	return
+}
+
+func parseToDeeplSupportedLanguage(lang string) string {
+	switch strings.ToLower(lang) {
+	case "zh", "zh-hans", "zh-cn", "chs":
+		return "ZH"
+	case "zh-hant", "zh-tw", "cht":
+		return "ZH"
+	case "en":
+		return "EN"
+	case "ja", "jp":
+		return "JA"
+	default:
+		return strings.ToUpper(lang)
+	}
+}
+
+func init() {
+	translate.Register(&DeepLX{})
+}

--- a/translate/deeplx/deeplx_test.go
+++ b/translate/deeplx/deeplx_test.go
@@ -1,0 +1,37 @@
+package deeplx
+
+import (
+	"os"
+	"testing"
+)
+
+func TestDeepLXTranslate(t *testing.T) {
+	baseURL := os.Getenv("DEEPLX_BASE_URL")
+	if baseURL == "" {
+		t.Skip("DEEPLX_BASE_URL not set")
+	}
+
+	apiKey := os.Getenv("DEEPLX_API_KEY")
+
+	translator := &DeepLX{
+		APIKey:  apiKey,
+		BaseURL: baseURL,
+	}
+
+	for _, unit := range []struct {
+		text, from, to string
+	}{
+		{`Oh yeah! I'm a translator!`, "auto", "ZH"},
+		{`私は翻訳者です`, "JA", "ZH"},
+		{`我是一个翻译器`, "ZH", "EN"},
+		{`PPPE-001 深田えいみ 親友からこっそり彼氏を寝取る巨乳でエッチな痴女お姉さん`, "JA", "ZH"},
+		{`A Busty and Naughty Sister Who Secretly Takes Her Best Friend's Boyfriend`, "EN", "ZH"},
+	} {
+		result, err := translator.Translate(unit.text, unit.from, unit.to)
+		if err != nil {
+			t.Errorf("Failed to translate text %q from %q to %q: %v", unit.text, unit.from, unit.to, err)
+			continue
+		}
+		t.Logf("Translated %q (%s->%s): %q", unit.text, unit.from, unit.to, result)
+	}
+}

--- a/translate/openai/openai_custom.go
+++ b/translate/openai/openai_custom.go
@@ -1,0 +1,92 @@
+package openai
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/metatube-community/metatube-sdk-go/common/fetch"
+	"github.com/metatube-community/metatube-sdk-go/translate"
+)
+
+var _ translate.Translator = (*OpenAIX)(nil)
+
+type OpenAIX struct {
+	APIKey   string `json:"openai-api-key"`
+	BaseURL  string `json:"base-url"`
+	Model    string `json:"model"`
+}
+
+func (oa *OpenAIX) Translate(q, source, target string) (result string, err error) {
+	if oa.BaseURL == "" {
+		return "", translate.ErrInvalidConfiguration
+	}
+
+	// Prepare the chat message
+	prompt := fmt.Sprintf(`You are a professional translator for adult video content. Please translate the following text from %s to %s.
+Rules:
+1. Keep actor/actress names and video codes unchanged
+2. Maintain any numbers, dates, and measurements in their original format
+3. Translate naturally and fluently, avoiding word-for-word translation
+4. Do not add any explanations or notes
+5. Only output the translation
+
+Text to translate:
+%s`, source, target, q)
+	
+	model := oa.Model
+	if model == "" {
+		model = "gpt-3.5-turbo"
+	}
+
+	reqBody := map[string]interface{}{
+		"model": model,
+		"messages": []map[string]string{
+			{
+				"role":    "user",
+				"content": prompt,
+			},
+		},
+		"temperature": 0.3,
+	}
+
+	reqJSON, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", err
+	}
+
+	var resp *http.Response
+	if resp, err = fetch.Post(
+		oa.BaseURL,
+		fetch.WithJSONBody(bytes.NewReader(reqJSON)),
+		fetch.WithRaiseForStatus(true),
+		fetch.WithHeader("Authorization", "Bearer "+oa.APIKey),
+		fetch.WithHeader("Content-Type", "application/json"),
+	); err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	var data struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+
+	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return
+	}
+
+	if len(data.Choices) > 0 {
+		result = strings.TrimSpace(data.Choices[0].Message.Content)
+	}
+	return
+}
+
+func init() {
+	translate.Register(&OpenAIX{})
+}

--- a/translate/openai/openai_custom.go
+++ b/translate/openai/openai_custom.go
@@ -28,11 +28,12 @@ func (oa *OpenAIX) Translate(q, source, target string) (result string, err error
 	// Prepare the chat message
 	prompt := fmt.Sprintf(`You are a professional translator for adult video content. Please translate the following text from %s to %s.
 Rules:
-1. Keep actor/actress names and video codes unchanged, output as is in translation
-2. Maintain any numbers, dates, and measurements in their original format
-3. Translate naturally and fluently, avoiding word-for-word translation
-4. Do not add any explanations or notes
-5. Only output the translation
+1. Use official translations for actor/actress names if available, otherwise keep them unchanged
+2. Do not invent translations for names without official versions
+3. Maintain any numbers, dates, and measurements in their original format
+4. Translate naturally and fluently, avoiding word-for-word translation
+5. Do not add any explanations or notes
+6. Only output the translation
 
 Text to translate:
 %s`, source, target, q)

--- a/translate/openai/openai_custom_test.go
+++ b/translate/openai/openai_custom_test.go
@@ -1,0 +1,39 @@
+package openai
+
+import (
+	"os"
+	"testing"
+)
+
+func TestOpenAiXTranslate(t *testing.T) {
+	baseURL := os.Getenv("OPENAI_X_BASE_URL")
+	if baseURL == "" {
+		t.Skip("OPENAI_X_BASE_URL not set")
+	}
+
+	apiKey := os.Getenv("OPENAI_X_API_KEY")
+	model := os.Getenv("OPENAI_X_MODEL")
+
+	translator := &OpenAIX{
+		APIKey:  apiKey,
+		BaseURL: baseURL,
+		Model:   model,
+	}
+
+	for _, unit := range []struct {
+		text, from, to string
+	}{
+		{`Oh yeah! I'm a translator!`, "EN", "ZH"},
+		{`私は翻訳者です`, "JA", "ZH"},
+		{`我是一个翻译器`, "ZH", "EN"},
+		{`PPPE-001 深田えいみ 親友からこっそり彼氏を寝取る巨乳でエッチな痴女お姉さん`, "JA", "ZH"},
+		{`A Busty and Naughty Sister Who Secretly Takes Her Best Friend's Boyfriend`, "EN", "ZH"},
+	} {
+		result, err := translator.Translate(unit.text, unit.from, unit.to)
+		if err != nil {
+			t.Errorf("Failed to translate text %q from %q to %q: %v", unit.text, unit.from, unit.to, err)
+			continue
+		}
+		t.Logf("Translated %q (%s->%s): %q", unit.text, unit.from, unit.to, result)
+	}
+}

--- a/translate/translate.go
+++ b/translate/translate.go
@@ -9,7 +9,10 @@ import (
 	"go.uber.org/atomic"
 )
 
-var ErrTranslator = &errorTranslator{errors.New("translate: unknown translator")}
+var (
+	ErrTranslator = &errorTranslator{errors.New("translate: unknown translator")}
+	ErrInvalidConfiguration = errors.New("translate: invalid configuration")
+)
 
 type Translator interface {
 	Translate(text, from, to string) (string, error)

--- a/translate/translate.go
+++ b/translate/translate.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	ErrTranslator = &errorTranslator{errors.New("translate: unknown translator")}
+	ErrTranslator           = &errorTranslator{errors.New("translate: unknown translator")}
 	ErrInvalidConfiguration = errors.New("translate: invalid configuration")
 )
 


### PR DESCRIPTION
增加了自定义翻译配置
新增了 deeplx 翻译引擎，可自定义 baseUrl、apiKey
新增了 openAiX 翻译引擎, 可自定义 baseUrl、apiKey、model

openAiX 可以使用与openAi兼容的服务，如 deepseek

方便使用代理站服务

> 此pr功能与 https://github.com/metatube-community/jellyfin-plugin-metatube/pull/434 功能相互配合


![image](https://github.com/user-attachments/assets/4d3e97e6-68e2-434e-b5db-f68a006a7393)

![image](https://github.com/user-attachments/assets/9819ba29-8f28-4c9d-abd9-db26720934dc)
