### PR TITLE
Fix(provider): deprecate `arzon`

### DIFF
--- a/engine/register.go
+++ b/engine/register.go
@@ -6,7 +6,6 @@ import (
 	_ "github.com/metatube-community/metatube-sdk-go/provider/10musume"
 	_ "github.com/metatube-community/metatube-sdk-go/provider/1pondo"
 	_ "github.com/metatube-community/metatube-sdk-go/provider/airav"
-	_ "github.com/metatube-community/metatube-sdk-go/provider/arzon"
 	_ "github.com/metatube-community/metatube-sdk-go/provider/av-league"
 	_ "github.com/metatube-community/metatube-sdk-go/provider/avbase"
 	_ "github.com/metatube-community/metatube-sdk-go/provider/aventertainments"

--- a/provider/arzon/arzon.go
+++ b/provider/arzon/arzon.go
@@ -1,3 +1,4 @@
+// Deprecated: This provider is no longer available.
 package arzon
 
 import (


### PR DESCRIPTION
As of April 1st, `Arzon` has stopped its service.