### PR TITLE
Refactor(provider): split actor image provider

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -87,6 +87,11 @@ func Router(names ...string) *gin.Engine {
 		opts = append(opts, engine.WithActorProviderPriorities(priorities))
 	}
 
+	// set actor image provider priorities if any
+	if priorities := env.ActorImageProviderPriorities(); len(priorities) > 0 {
+		opts = append(opts, engine.WithActorImageProviderPriorities(priorities))
+	}
+
 	// set movie provider priorities if any
 	if priorities := env.MovieProviderPriorities(); len(priorities) > 0 {
 		opts = append(opts, engine.WithMovieProviderPriorities(priorities))

--- a/engine/actor_test.go
+++ b/engine/actor_test.go
@@ -1,0 +1,190 @@
+package engine
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/text/language"
+
+	"github.com/metatube-community/metatube-sdk-go/database"
+	"github.com/metatube-community/metatube-sdk-go/model"
+	mt "github.com/metatube-community/metatube-sdk-go/provider"
+)
+
+func setupTestEngine(t *testing.T) *Engine {
+	db, err := database.Open(&database.Config{}) // In-memory SQLite
+	assert.NoError(t, err)
+	err = db.AutoMigrate(&model.ActorInfo{})
+	assert.NoError(t, err)
+	engine := &Engine{
+		db:      db,
+		name:    DefaultEngineName,
+		timeout: DefaultRequestTimeout,
+	}
+	engine.initLogger()
+	return engine
+}
+
+type testActorProvider struct {
+	lang language.Tag
+}
+
+func (s *testActorProvider) Name() string {
+	return ""
+}
+
+func (s *testActorProvider) Priority() float64 {
+	return 0.0
+}
+
+func (s *testActorProvider) SetPriority(v float64) {
+}
+
+func (s *testActorProvider) Language() language.Tag {
+	return s.lang
+}
+
+func (s *testActorProvider) URL() *url.URL {
+	return nil
+}
+
+func (s *testActorProvider) NormalizeActorID(id string) string {
+	return ""
+}
+
+func (s *testActorProvider) ParseActorIDFromURL(rawURL string) (string, error) {
+	return "", nil
+}
+
+func (s *testActorProvider) GetActorInfoByID(id string) (*model.ActorInfo, error) {
+	return nil, nil
+}
+
+func (s *testActorProvider) GetActorInfoByURL(url string) (*model.ActorInfo, error) {
+	return nil, nil
+}
+
+type testActorImageProvider struct {
+	returnImages []string
+}
+
+func (s *testActorImageProvider) Name() string {
+	return ""
+}
+
+func (s *testActorImageProvider) Priority() float64 {
+	return 0.0
+}
+
+func (s *testActorImageProvider) SetPriority(v float64) {
+}
+
+func (s *testActorImageProvider) Language() language.Tag {
+	return language.Japanese
+}
+
+func (s *testActorImageProvider) URL() *url.URL {
+	return nil
+}
+
+func (s *testActorImageProvider) GetActorImagesByName(name string) ([]string, error) {
+	return s.returnImages, nil
+}
+
+func TestGetActorInfoWithCallback(t *testing.T) {
+	const notLazy = false
+
+	engine := setupTestEngine(t)
+	actorImageProvider := &testActorImageProvider{}
+
+	engine.actorImageLanguageProviders = make(map[string][]mt.ActorImageProvider)
+	engine.actorImageLanguageProviders[language.Japanese.String()] = []mt.ActorImageProvider{
+		actorImageProvider,
+	}
+
+	actorProviderInJapanese := &testActorProvider{lang: language.Japanese}
+	actorProviderInChinese := &testActorProvider{lang: language.Chinese}
+
+	tests := []struct {
+		name                           string
+		callbackReturnActorInfo        *model.ActorInfo
+		actorImageProviderReturnImages []string
+		actorProvider                  mt.ActorProvider
+		expectedError                  error
+		expectedImages                 pq.StringArray
+	}{
+		{
+			name:                           "CallbackCannotFindInfo",
+			callbackReturnActorInfo:        nil,
+			actorImageProviderReturnImages: nil,
+			actorProvider:                  actorProviderInJapanese,
+			expectedError:                  mt.ErrInfoNotFound,
+			expectedImages:                 nil,
+		},
+		{
+			name: "NoImageProviders",
+			callbackReturnActorInfo: &model.ActorInfo{
+				ID:       "id",
+				Name:     "name",
+				Provider: "provider",
+				Homepage: "homepage",
+				Images:   []string{"image1.jpg"},
+			},
+			actorImageProviderReturnImages: nil,
+			actorProvider:                  actorProviderInChinese,
+			expectedError:                  nil,
+			expectedImages:                 []string{"image1.jpg"},
+		},
+		{
+			name: "ImageProviderReturnsNothing",
+			callbackReturnActorInfo: &model.ActorInfo{
+				ID:       "id",
+				Name:     "name",
+				Provider: "provider",
+				Homepage: "homepage",
+				Images:   []string{"image1.jpg"},
+			},
+			actorImageProviderReturnImages: nil,
+			actorProvider:                  actorProviderInJapanese,
+			expectedError:                  nil,
+			expectedImages:                 []string{"image1.jpg"},
+		},
+		{
+			name: "ImageProviderReturnsItems",
+			callbackReturnActorInfo: &model.ActorInfo{
+				ID:       "id",
+				Name:     "name",
+				Provider: "provider",
+				Homepage: "homepage",
+				Images:   []string{"image1.jpg"},
+			},
+			actorImageProviderReturnImages: []string{"image2.jpg", "image3.jpg"},
+			actorProvider:                  actorProviderInJapanese,
+			expectedError:                  nil,
+			expectedImages:                 []string{"image1.jpg", "image2.jpg", "image3.jpg"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actorImageProvider.returnImages = tt.actorImageProviderReturnImages
+
+			callback := func() (*model.ActorInfo, error) {
+				return tt.callbackReturnActorInfo, nil
+			}
+
+			info, err := engine.getActorInfoWithCallback(tt.actorProvider, "id", notLazy, callback)
+
+			if tt.expectedError != nil {
+				assert.Equal(t, tt.expectedError, err)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, info)
+				assert.Equal(t, tt.expectedImages, info.Images)
+			}
+		})
+	}
+}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/text/language"
 	"gorm.io/gorm"
 
 	"github.com/metatube-community/metatube-sdk-go/common/fetch"
@@ -27,14 +28,18 @@ type Engine struct {
 	// Engine Logger
 	logger *log.Logger
 	// Name:Provider Map
-	actorProviders map[string]mt.ActorProvider
-	movieProviders map[string]mt.MovieProvider
+	actorProviders      map[string]mt.ActorProvider
+	actorImageProviders map[string]mt.ActorImageProvider
+	movieProviders      map[string]mt.MovieProvider
 	// Name:Priority Map
-	actorPriorities map[string]float64
-	moviePriorities map[string]float64
+	actorPriorities      map[string]float64
+	actorImagePriorities map[string]float64
+	moviePriorities      map[string]float64
 	// Host:Providers Map
 	actorHostProviders map[string][]mt.ActorProvider
 	movieHostProviders map[string][]mt.MovieProvider
+	// LanguageTag:Providers
+	actorImageLanguageProviders map[string][]mt.ActorImageProvider
 }
 
 func New(db *gorm.DB, opts ...Option) *Engine {
@@ -96,6 +101,14 @@ func (e *Engine) MustGetActorProviderByName(name string) mt.ActorProvider {
 		panic(err)
 	}
 	return provider
+}
+
+func (e *Engine) GetActorImageProviders() map[string]mt.ActorImageProvider {
+	return e.actorImageProviders
+}
+
+func (e *Engine) GetActorImageProviderByLanguage(lang language.Tag) []mt.ActorImageProvider {
+	return e.actorImageLanguageProviders[lang.String()]
 }
 
 func (e *Engine) IsMovieProvider(name string) (ok bool) {

--- a/engine/option.go
+++ b/engine/option.go
@@ -24,6 +24,12 @@ func WithActorProviderPriorities(priorities map[string]float64) Option {
 	}
 }
 
+func WithActorImageProviderPriorities(priorities map[string]float64) Option {
+	return func(e *Engine) {
+		e.actorImagePriorities = priorities
+	}
+}
+
 func WithMovieProviderPriorities(priorities map[string]float64) Option {
 	return func(e *Engine) {
 		e.moviePriorities = priorities

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -10,8 +10,9 @@ const MetaTubeEnvPrefix = "MT_"
 
 // Special environment prefixes for setting provider priorities.
 const (
-	actorProviderPriorityEnvPrefix = MetaTubeEnvPrefix + "ACTOR_PROVIDER_PRIORITY_"
-	movieProviderPriorityEnvPrefix = MetaTubeEnvPrefix + "MOVIE_PROVIDER_PRIORITY_"
+	actorProviderPriorityEnvPrefix      = MetaTubeEnvPrefix + "ACTOR_PROVIDER_PRIORITY_"
+	actorImageProviderPriorityEnvPrefix = MetaTubeEnvPrefix + "ACTOR_IMAGE_PROVIDER_PRIORITY_"
+	movieProviderPriorityEnvPrefix      = MetaTubeEnvPrefix + "MOVIE_PROVIDER_PRIORITY_"
 )
 
 var _metaTubeEnvs map[string]string
@@ -54,6 +55,10 @@ func getProviderPriorities(prefix string) map[string]float64 {
 
 func ActorProviderPriorities() map[string]float64 {
 	return getProviderPriorities(actorProviderPriorityEnvPrefix)
+}
+
+func ActorImageProviderPriorities() map[string]float64 {
+	return getProviderPriorities(actorImageProviderPriorityEnvPrefix)
 }
 
 func MovieProviderPriorities() map[string]float64 {

--- a/provider/gfriends/gfriends.go
+++ b/provider/gfriends/gfriends.go
@@ -13,22 +13,16 @@ import (
 	"github.com/metatube-community/metatube-sdk-go/collections"
 	"github.com/metatube-community/metatube-sdk-go/common/fetch"
 	"github.com/metatube-community/metatube-sdk-go/common/singledo"
-	"github.com/metatube-community/metatube-sdk-go/model"
 	"github.com/metatube-community/metatube-sdk-go/provider"
 	"github.com/metatube-community/metatube-sdk-go/provider/internal/scraper"
 )
 
-var (
-	_ provider.ActorProvider = (*Gfriends)(nil)
-	_ provider.ActorSearcher = (*Gfriends)(nil)
-)
+var _ provider.ActorImageProvider = (*Gfriends)(nil)
 
 const (
 	Name     = "Gfriends"
 	Priority = 1000 - 1
 )
-
-const gFriendsID = "gfriends-id"
 
 const (
 	baseURL    = "https://github.com/gfriends/gfriends"
@@ -48,54 +42,12 @@ func New() *Gfriends {
 	)}
 }
 
-func (gf *Gfriends) GetActorInfoByID(id string) (*model.ActorInfo, error) {
-	images, err := _fileTree.query(id)
-	if len(images) == 0 {
-		if err != nil {
-			return nil, err
-		}
-		return nil, provider.ErrInfoNotFound
-	}
-	return &model.ActorInfo{
-		ID:       id,
-		Name:     id,
-		Provider: gf.Name(),
-		Homepage: gf.formatURL(id),
-		Aliases:  []string{},
-		Images:   images,
-	}, nil
-}
-
-func (gf *Gfriends) formatURL(id string) string {
-	u, _ := url.Parse(baseURL)
-	q := u.Query()
-	q.Set(gFriendsID, id)
-	u.RawQuery = q.Encode()
-	return u.String()
-}
-
-func (gf *Gfriends) ParseActorIDFromURL(rawURL string) (string, error) {
-	homepage, err := url.Parse(rawURL)
-	if err != nil {
-		return "", err
-	}
-	return homepage.Query().Get(gFriendsID), nil
-}
-
-func (gf *Gfriends) GetActorInfoByURL(u string) (*model.ActorInfo, error) {
-	id, err := gf.ParseActorIDFromURL(u)
+func (gf *Gfriends) GetActorImagesByName(name string) ([]string, error) {
+	images, err := _fileTree.query(name)
 	if err != nil {
 		return nil, err
 	}
-	return gf.GetActorInfoByID(id)
-}
-
-func (gf *Gfriends) SearchActor(keyword string) (results []*model.ActorSearchResult, err error) {
-	var info *model.ActorInfo
-	if info, err = gf.GetActorInfoByID(keyword); err == nil && info.Valid() {
-		results = []*model.ActorSearchResult{info.ToSearchResult()}
-	}
-	return
+	return images, nil
 }
 
 var (

--- a/provider/gfriends/gfriends_test.go
+++ b/provider/gfriends/gfriends_test.go
@@ -6,23 +6,7 @@ import (
 	"github.com/metatube-community/metatube-sdk-go/provider/internal/testkit"
 )
 
-func TestGfriends_GetActorInfoByID(t *testing.T) {
-	testkit.Test(t, New, []string{
-		"小澤マリア",
-		"小松凛花",
-		"谷あづさ",
-		"若宮はずき",
-	})
-}
-
-func TestGfriends_GetActorInfoByURL(t *testing.T) {
-	testkit.Test(t, New, []string{
-		"https://github.com/gfriends/gfriends?gfriends-id=%E5%B0%8F%E6%9D%BE%E5%87%9B%E8%8A%B1",
-		"https://github.com/gfriends/gfriends?gfriends-id=%E8%B0%B7%E3%81%82%E3%81%A5%E3%81%95",
-	})
-}
-
-func TestGfriends_SearchActor(t *testing.T) {
+func TestGfriends_GetActorImagesByName(t *testing.T) {
 	testkit.Test(t, New, []string{
 		"美竹すず",
 	})

--- a/provider/internal/testkit/testkit.go
+++ b/provider/internal/testkit/testkit.go
@@ -147,6 +147,19 @@ func (s *internalTestSuite) TestFetch(p mt.Fetcher, items []string, vfs ...Valid
 	})
 }
 
+func (s *internalTestSuite) TestGetActorImagesByName(p mt.ActorImageProvider, items []string, vfs ...ValidateFunc) {
+	s.testItems(items, func(t *testing.T, item string) {
+		images, err := p.GetActorImagesByName(item)
+		require.NoError(t, err)
+		require.NotEmpty(t, images)
+		for _, vf := range append([]ValidateFunc{
+			logJSONContent(),
+		}, vfs...) {
+			vf(t, images)
+		}
+	})
+}
+
 func Test[T mt.Provider](t *testing.T, new func() T, items []string, vfs ...ValidateFunc) {
 	if ci, _ := strconv.ParseBool(os.Getenv("GITHUB_ACTIONS")); ci {
 		t.SkipNow() // Skip in GitHub Actions

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -82,6 +82,14 @@ type ActorProvider interface {
 	GetActorInfoByURL(url string) (*model.ActorInfo, error)
 }
 
+type ActorImageProvider interface {
+	// Provider should be implemented.
+	Provider
+
+	// GetActorImagesByName gets actor's images by actor's name.
+	GetActorImagesByName(name string) ([]string, error)
+}
+
 type Fetcher interface {
 	// Fetch fetches media resources from url.
 	Fetch(url string) (*http.Response, error)

--- a/route/route.go
+++ b/route/route.go
@@ -124,14 +124,19 @@ func getModules() gin.HandlerFunc {
 
 func getProviders(app *engine.Engine) gin.HandlerFunc {
 	data := struct {
-		ActorProviders map[string]string `json:"actor_providers"`
-		MovieProviders map[string]string `json:"movie_providers"`
+		ActorProviders      map[string]string `json:"actor_providers"`
+		ActorImageProviders map[string]string `json:"actor_image_providers"`
+		MovieProviders      map[string]string `json:"movie_providers"`
 	}{
-		ActorProviders: make(map[string]string),
-		MovieProviders: make(map[string]string),
+		ActorProviders:      make(map[string]string),
+		ActorImageProviders: make(map[string]string),
+		MovieProviders:      make(map[string]string),
 	}
 	for _, provider := range app.GetActorProviders() {
 		data.ActorProviders[provider.Name()] = provider.URL().String()
+	}
+	for _, provider := range app.GetActorImageProviders() {
+		data.ActorImageProviders[provider.Name()] = provider.URL().String()
 	}
 	for _, provider := range app.GetMovieProviders() {
 		data.MovieProviders[provider.Name()] = provider.URL().String()


### PR DESCRIPTION
This refactor makes `getActorInfoWithCallback()` more readible and less hard code. It also make following add new actor provider easier.

https://github.com/metatube-community/metatube-sdk-go/issues/192#issuecomment-2798950103