### PR TITLE
Fix movie title extraction to remove spam content

### DIFF
--- a/provider/fc2/fc2.go
+++ b/provider/fc2/fc2.go
@@ -9,12 +9,13 @@ import (
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/gocolly/colly/v2"
+	"golang.org/x/text/language"
+
 	"github.com/metatube-community/metatube-sdk-go/common/parser"
 	"github.com/metatube-community/metatube-sdk-go/model"
 	"github.com/metatube-community/metatube-sdk-go/provider"
 	"github.com/metatube-community/metatube-sdk-go/provider/fc2/fc2util"
 	"github.com/metatube-community/metatube-sdk-go/provider/internal/scraper"
-	"golang.org/x/text/language"
 )
 
 var _ provider.MovieProvider = (*FC2)(nil)

--- a/provider/fc2/fc2.go
+++ b/provider/fc2/fc2.go
@@ -77,7 +77,7 @@ func (fc2 *FC2) GetMovieInfoByURL(rawURL string) (info *model.MovieInfo, err err
 	c.OnXML(`//div[@class="items_article_headerInfo"]`, func(e *colly.XMLElement) {
 		// Modified title extraction
 		rawTitle := e.ChildText(`./h3`) // Get all text content from h3 element
-		
+
 		// Process as HTML
 		doc, err := goquery.NewDocumentFromReader(strings.NewReader("<h3>" + rawTitle + "</h3>"))
 		if err == nil {
@@ -90,7 +90,7 @@ func (fc2 *FC2) GetMovieInfoByURL(rawURL string) (info *model.MovieInfo, err err
 					s.Remove()
 				}
 			})
-			
+
 			// Get clean text
 			info.Title = strings.TrimSpace(doc.Text())
 		} else {

--- a/provider/fc2/fc2.go
+++ b/provider/fc2/fc2.go
@@ -9,13 +9,12 @@ import (
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/gocolly/colly/v2"
-	"golang.org/x/text/language"
-
 	"github.com/metatube-community/metatube-sdk-go/common/parser"
 	"github.com/metatube-community/metatube-sdk-go/model"
 	"github.com/metatube-community/metatube-sdk-go/provider"
 	"github.com/metatube-community/metatube-sdk-go/provider/fc2/fc2util"
 	"github.com/metatube-community/metatube-sdk-go/provider/internal/scraper"
+	"golang.org/x/text/language"
 )
 
 var _ provider.MovieProvider = (*FC2)(nil)
@@ -84,9 +83,9 @@ func (fc2 *FC2) GetMovieInfoByURL(rawURL string) (info *model.MovieInfo, err err
 			// Remove spam-like spans
 			doc.Find("span").Each(func(i int, s *goquery.Selection) {
 				style, exists := s.Attr("style")
-				if exists && (strings.Contains(style, "zoom:0.01") || 
-						strings.Contains(style, "display:none") || 
-						strings.Contains(style, "overflow:hidden")) {
+				if exists && (strings.Contains(style, "zoom:0.01") ||
+					strings.Contains(style, "display:none") ||
+					strings.Contains(style, "overflow:hidden")) {
 					s.Remove()
 				}
 			})


### PR DESCRIPTION
## Explanation
This PR improves title extraction from FC2 pages by properly handling hidden spam text in span tags.
The current implementation only extracts direct text nodes under h3 elements,
missing the full title content that includes text in span tags. This change enhances
title extraction by:
- Using `ChildText` to get complete text including child elements
- Adding HTML parsing with goquery to remove spam-like spans
- Implementing regex fallback for cleaning when parsing fails

## Problem
The current implementation uses `e.ChildTexts(./h3/text())` which only extracts text nodes directly under h3 elements. This causes a serious issue where only the beginning part of the title (before any span tags) is captured, while the rest of the title after span tags is completely missed.

For example, with this HTML:
```html
<h3>【ほげほげ】<span style="zoom:0.01;...">***o*xspn*jx </span>もげもげ</h3>
```

The current code only extracts `"【ほげほげ】"` and completely misses `"もげもげ"` (the actual main part of the title).

## Solution
The new implementation gets the full text content first with `e.ChildText(./h3)`, which captures all text including those after span tags. It then uses goquery to clean the HTML by removing span elements that have spam-like style attributes. This results in a complete title where both the beginning part and the part after spam spans are properly joined: `"【ほげほげ】もげもげ"`