### PR TITLE
Fix(engine): preserve existing optional fields on metadata upsert

### DIFF
--- a/engine/actor.go
+++ b/engine/actor.go
@@ -177,6 +177,13 @@ func (e *Engine) getActorInfoWithCallback(provider mt.ActorProvider, id string, 
 	// Delayed info auto-save.
 	defer func() {
 		if err == nil && info.IsValid() {
+			// Preserve any non-empty fields from the existing DB record, so a
+			// fresh fetch that returned empty optional fields doesn't clobber
+			// previously-stored good data. IsValid() already guarantees the
+			// required (primary key) fields are populated on info.
+			if existing, dbErr := e.getActorInfoFromDB(provider, id); dbErr == nil {
+				info.PreserveFrom(existing)
+			}
 			// Make sure we save the original info here.
 			e.db.Clauses(clause.OnConflict{
 				UpdateAll: true,

--- a/engine/engine_persist_actor_test.go
+++ b/engine/engine_persist_actor_test.go
@@ -1,0 +1,179 @@
+package engine
+
+import (
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+	"golang.org/x/text/language"
+	"gorm.io/datatypes"
+
+	mt "github.com/metatube-community/metatube-sdk-go/provider"
+
+	"github.com/metatube-community/metatube-sdk-go/model"
+)
+
+// fakeActorProvider implements mt.ActorProvider for tests. Language is set to
+// English by default so the gfriends image-injection defer in
+// getActorInfoWithCallback is skipped (it only triggers for Japanese providers
+// and would require a registered gfriends provider).
+type fakeActorProvider struct {
+	name string
+	url  *url.URL
+	lang language.Tag
+	next *model.ActorInfo
+	err  error
+}
+
+func (f *fakeActorProvider) Name() string                              { return f.name }
+func (f *fakeActorProvider) Priority() float64                         { return 1 }
+func (f *fakeActorProvider) SetPriority(v float64)                     {}
+func (f *fakeActorProvider) Language() language.Tag                    { return f.lang }
+func (f *fakeActorProvider) URL() *url.URL                             { return f.url }
+func (f *fakeActorProvider) NormalizeActorID(id string) string         { return id }
+func (f *fakeActorProvider) ParseActorIDFromURL(string) (string, error) {
+	return "", nil
+}
+func (f *fakeActorProvider) GetActorInfoByID(id string) (*model.ActorInfo, error) {
+	return f.next, f.err
+}
+func (f *fakeActorProvider) GetActorInfoByURL(string) (*model.ActorInfo, error) {
+	return f.next, f.err
+}
+
+var _ mt.ActorProvider = (*fakeActorProvider)(nil)
+
+func newFakeActorProvider(name string) *fakeActorProvider {
+	u, _ := url.Parse("https://example.com/")
+	return &fakeActorProvider{name: name, url: u, lang: language.English}
+}
+
+func fullActorInfo(id, provider string) *model.ActorInfo {
+	return &model.ActorInfo{
+		ID:           id,
+		Name:         "Existing Alice",
+		Provider:     provider,
+		Homepage:     "https://example.com/" + id,
+		Summary:      "Full bio.",
+		Hobby:        "Hobby X",
+		Skill:        "Skill Y",
+		BloodType:    "A",
+		CupSize:      "C",
+		Measurements: "B85-W58-H86",
+		Nationality:  "Japan",
+		Height:       165,
+		Aliases:      pq.StringArray{"alias1", "alias2"},
+		Images:       pq.StringArray{"https://example.com/img1.jpg"},
+		Birthday:     datatypes.Date(time.Date(1995, 1, 1, 0, 0, 0, 0, time.UTC)),
+		DebutDate:    datatypes.Date(time.Date(2015, 6, 1, 0, 0, 0, 0, time.UTC)),
+	}
+}
+
+func minimalActorInfo(id, provider string) *model.ActorInfo {
+	return &model.ActorInfo{
+		ID:       id,
+		Name:     "Existing Alice",
+		Provider: provider,
+		Homepage: "https://example.com/" + id,
+	}
+}
+
+// TestGetActorInfo_EmptyFieldsDoNotClobberExisting is the actor-side analog of
+// TestGetMovieInfo_EmptyFieldsDoNotClobberExisting. It verifies that a fetch
+// returning only the IsValid() fields does not wipe the actor's Summary,
+// Aliases, Images, Birthday, etc. from the DB.
+func TestGetActorInfo_EmptyFieldsDoNotClobberExisting(t *testing.T) {
+	e := newTestEngine(t)
+	p := newFakeActorProvider("FakeActorProvider")
+
+	id := "a-1"
+
+	// --- Step 1: full insert.
+	full := fullActorInfo(id, p.name)
+	p.next = full
+	if _, err := e.getActorInfoByProviderID(p, id, false /* lazy */); err != nil {
+		t.Fatalf("step 1: %v", err)
+	}
+
+	stored, err := e.getActorInfoFromDB(p, id)
+	if err != nil {
+		t.Fatalf("DB read after step 1: %v", err)
+	}
+	if stored.Summary != full.Summary {
+		t.Fatalf("step 1: DB Summary mismatch")
+	}
+
+	// --- Step 2: provider returns minimal info.
+	p.next = minimalActorInfo(id, p.name)
+	if _, err := e.getActorInfoByProviderID(p, id, false /* lazy */); err != nil {
+		t.Fatalf("step 2: %v", err)
+	}
+
+	stored2, err := e.getActorInfoFromDB(p, id)
+	if err != nil {
+		t.Fatalf("DB read after step 2: %v", err)
+	}
+	if stored2.Summary != full.Summary {
+		t.Errorf("step 2: DB Summary was clobbered, got %q want %q",
+			stored2.Summary, full.Summary)
+	}
+	if stored2.Hobby != full.Hobby {
+		t.Errorf("step 2: DB Hobby was clobbered, got %q", stored2.Hobby)
+	}
+	if stored2.BloodType != full.BloodType {
+		t.Errorf("step 2: DB BloodType was clobbered, got %q", stored2.BloodType)
+	}
+	if stored2.Height != full.Height {
+		t.Errorf("step 2: DB Height was clobbered, got %d", stored2.Height)
+	}
+	if len(stored2.Aliases) != len(full.Aliases) {
+		t.Errorf("step 2: DB Aliases was clobbered, got %v", stored2.Aliases)
+	}
+	if len(stored2.Images) != len(full.Images) {
+		t.Errorf("step 2: DB Images was clobbered, got %v", stored2.Images)
+	}
+	if time.Time(stored2.Birthday) != time.Time(full.Birthday) {
+		t.Errorf("step 2: DB Birthday was clobbered, got %v", time.Time(stored2.Birthday))
+	}
+	if time.Time(stored2.DebutDate) != time.Time(full.DebutDate) {
+		t.Errorf("step 2: DB DebutDate was clobbered, got %v", time.Time(stored2.DebutDate))
+	}
+}
+
+// TestGetActorInfo_NonEmptyFieldsWinOverExisting confirms the converse for
+// actors: a non-empty fresh fetch replaces the corresponding DB column.
+func TestGetActorInfo_NonEmptyFieldsWinOverExisting(t *testing.T) {
+	e := newTestEngine(t)
+	p := newFakeActorProvider("FakeActorProvider")
+
+	id := "a-1"
+
+	p.next = fullActorInfo(id, p.name)
+	if _, err := e.getActorInfoByProviderID(p, id, false); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	v2 := fullActorInfo(id, p.name)
+	v2.Summary = "Updated bio - v2."
+	v2.Height = 170
+	v2.Aliases = pq.StringArray{"new-alias"}
+	p.next = v2
+	if _, err := e.getActorInfoByProviderID(p, id, false); err != nil {
+		t.Fatalf("v2: %v", err)
+	}
+
+	stored, err := e.getActorInfoFromDB(p, id)
+	if err != nil {
+		t.Fatalf("DB read: %v", err)
+	}
+	if stored.Summary != "Updated bio - v2." {
+		t.Errorf("Summary v2 should win, got %q", stored.Summary)
+	}
+	if stored.Height != 170 {
+		t.Errorf("Height v2 should win, got %d", stored.Height)
+	}
+	if len(stored.Aliases) != 1 || stored.Aliases[0] != "new-alias" {
+		t.Errorf("Aliases v2 should replace v1, got %v", stored.Aliases)
+	}
+}

--- a/engine/engine_persist_actor_test.go
+++ b/engine/engine_persist_actor_test.go
@@ -9,9 +9,8 @@ import (
 	"golang.org/x/text/language"
 	"gorm.io/datatypes"
 
-	mt "github.com/metatube-community/metatube-sdk-go/provider"
-
 	"github.com/metatube-community/metatube-sdk-go/model"
+	mt "github.com/metatube-community/metatube-sdk-go/provider"
 )
 
 // fakeActorProvider implements mt.ActorProvider for tests. Language is set to
@@ -26,18 +25,20 @@ type fakeActorProvider struct {
 	err  error
 }
 
-func (f *fakeActorProvider) Name() string                              { return f.name }
-func (f *fakeActorProvider) Priority() float64                         { return 1 }
-func (f *fakeActorProvider) SetPriority(v float64)                     {}
-func (f *fakeActorProvider) Language() language.Tag                    { return f.lang }
-func (f *fakeActorProvider) URL() *url.URL                             { return f.url }
-func (f *fakeActorProvider) NormalizeActorID(id string) string         { return id }
+func (f *fakeActorProvider) Name() string                      { return f.name }
+func (f *fakeActorProvider) Priority() float64                 { return 1 }
+func (f *fakeActorProvider) SetPriority(v float64)             {}
+func (f *fakeActorProvider) Language() language.Tag            { return f.lang }
+func (f *fakeActorProvider) URL() *url.URL                     { return f.url }
+func (f *fakeActorProvider) NormalizeActorID(id string) string { return id }
 func (f *fakeActorProvider) ParseActorIDFromURL(string) (string, error) {
 	return "", nil
 }
+
 func (f *fakeActorProvider) GetActorInfoByID(id string) (*model.ActorInfo, error) {
 	return f.next, f.err
 }
+
 func (f *fakeActorProvider) GetActorInfoByURL(string) (*model.ActorInfo, error) {
 	return f.next, f.err
 }

--- a/engine/engine_persist_test.go
+++ b/engine/engine_persist_test.go
@@ -10,9 +10,8 @@ import (
 	"gorm.io/datatypes"
 
 	"github.com/metatube-community/metatube-sdk-go/database"
-	mt "github.com/metatube-community/metatube-sdk-go/provider"
-
 	"github.com/metatube-community/metatube-sdk-go/model"
+	mt "github.com/metatube-community/metatube-sdk-go/provider"
 )
 
 // newTestEngine builds an Engine backed by a fresh in-memory SQLite, with all
@@ -43,18 +42,20 @@ type fakeMovieProvider struct {
 	err  error
 }
 
-func (f *fakeMovieProvider) Name() string                            { return f.name }
-func (f *fakeMovieProvider) Priority() float64                       { return 1 }
-func (f *fakeMovieProvider) SetPriority(v float64)                   {}
-func (f *fakeMovieProvider) Language() language.Tag                  { return language.Japanese }
-func (f *fakeMovieProvider) URL() *url.URL                           { return f.url }
-func (f *fakeMovieProvider) NormalizeMovieID(id string) string       { return id }
+func (f *fakeMovieProvider) Name() string                      { return f.name }
+func (f *fakeMovieProvider) Priority() float64                 { return 1 }
+func (f *fakeMovieProvider) SetPriority(v float64)             {}
+func (f *fakeMovieProvider) Language() language.Tag            { return language.Japanese }
+func (f *fakeMovieProvider) URL() *url.URL                     { return f.url }
+func (f *fakeMovieProvider) NormalizeMovieID(id string) string { return id }
 func (f *fakeMovieProvider) ParseMovieIDFromURL(string) (string, error) {
 	return "", nil
 }
+
 func (f *fakeMovieProvider) GetMovieInfoByID(id string) (*model.MovieInfo, error) {
 	return f.next, f.err
 }
+
 func (f *fakeMovieProvider) GetMovieInfoByURL(string) (*model.MovieInfo, error) {
 	return f.next, f.err
 }

--- a/engine/engine_persist_test.go
+++ b/engine/engine_persist_test.go
@@ -1,0 +1,322 @@
+package engine
+
+import (
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+	"golang.org/x/text/language"
+	"gorm.io/datatypes"
+
+	"github.com/metatube-community/metatube-sdk-go/database"
+	mt "github.com/metatube-community/metatube-sdk-go/provider"
+
+	"github.com/metatube-community/metatube-sdk-go/model"
+)
+
+// newTestEngine builds an Engine backed by a fresh in-memory SQLite, with all
+// model tables migrated. Each call returns an isolated DB.
+func newTestEngine(t *testing.T) *Engine {
+	t.Helper()
+	// Use a unique DSN per test so parallel runs don't share state. SQLite's
+	// `:memory:` is per-connection; `file::memory:?cache=shared` is shared
+	// across connections of the SAME DSN, so we vary the name.
+	dsn := "file:" + t.Name() + "?mode=memory&cache=shared"
+	db, err := database.Open(&database.Config{DSN: dsn, DisableAutomaticPing: true})
+	if err != nil {
+		t.Fatalf("database.Open: %v", err)
+	}
+	e := New(db)
+	if err := e.DBAutoMigrate(true); err != nil {
+		t.Fatalf("DBAutoMigrate: %v", err)
+	}
+	return e
+}
+
+// fakeMovieProvider implements mt.MovieProvider for tests. Its GetMovieInfoByID
+// returns whatever the test sets in `next`.
+type fakeMovieProvider struct {
+	name string
+	url  *url.URL
+	next *model.MovieInfo
+	err  error
+}
+
+func (f *fakeMovieProvider) Name() string                            { return f.name }
+func (f *fakeMovieProvider) Priority() float64                       { return 1 }
+func (f *fakeMovieProvider) SetPriority(v float64)                   {}
+func (f *fakeMovieProvider) Language() language.Tag                  { return language.Japanese }
+func (f *fakeMovieProvider) URL() *url.URL                           { return f.url }
+func (f *fakeMovieProvider) NormalizeMovieID(id string) string       { return id }
+func (f *fakeMovieProvider) ParseMovieIDFromURL(string) (string, error) {
+	return "", nil
+}
+func (f *fakeMovieProvider) GetMovieInfoByID(id string) (*model.MovieInfo, error) {
+	return f.next, f.err
+}
+func (f *fakeMovieProvider) GetMovieInfoByURL(string) (*model.MovieInfo, error) {
+	return f.next, f.err
+}
+
+var _ mt.MovieProvider = (*fakeMovieProvider)(nil)
+
+func newFakeMovieProvider(name string) *fakeMovieProvider {
+	u, _ := url.Parse("https://example.com/")
+	return &fakeMovieProvider{name: name, url: u}
+}
+
+func fullMovieInfo(id, provider string) *model.MovieInfo {
+	return &model.MovieInfo{
+		ID:                 id,
+		Number:             "NUM-001",
+		Title:              "Full Title",
+		Summary:            "Full summary, the good one.",
+		Provider:           provider,
+		Homepage:           "https://example.com/" + id,
+		Director:           "Director X",
+		Actors:             pq.StringArray{"actor1", "actor2"},
+		ThumbURL:           "https://example.com/thumb.jpg",
+		BigThumbURL:        "https://example.com/big-thumb.jpg",
+		CoverURL:           "https://example.com/cover.jpg",
+		BigCoverURL:        "https://example.com/big-cover.jpg",
+		PreviewVideoURL:    "https://example.com/preview.mp4",
+		PreviewVideoHLSURL: "https://example.com/preview.m3u8",
+		PreviewImages:      pq.StringArray{"https://example.com/p1.jpg"},
+		Maker:              "Maker M",
+		Label:              "Label L",
+		Series:             "Series S",
+		Genres:             pq.StringArray{"genre1", "genre2"},
+		Score:              4.5,
+		Runtime:            120,
+		ReleaseDate:        datatypes.Date(time.Date(2024, 2, 13, 0, 0, 0, 0, time.UTC)),
+	}
+}
+
+// minimalMovieInfo returns a MovieInfo that passes IsValid() but has every
+// optional field at its zero value - the "regression case" that used to
+// clobber the DB.
+func minimalMovieInfo(id, provider string) *model.MovieInfo {
+	return &model.MovieInfo{
+		ID:       id,
+		Number:   "NUM-001",
+		Title:    "Full Title",
+		CoverURL: "https://example.com/cover.jpg",
+		Provider: provider,
+		Homepage: "https://example.com/" + id,
+	}
+}
+
+// TestGetMovieInfo_EmptyFieldsDoNotClobberExisting is the central regression
+// test for the JAV321/JavBus "empty summary overwrites good summary" bug. It
+// reproduces the failure sequence:
+//
+//  1. Fetch #1 returns a fully-populated MovieInfo. DB persists it.
+//  2. Fetch #2 (e.g. provider had a transient miss, or it's a provider like
+//     JavBus that doesn't populate Summary) returns a MovieInfo with the
+//     required IsValid() fields but every optional field empty.
+//
+// With UpdateAll: true and no PreserveFrom, step 2 used to wipe Summary,
+// Director, Actors, Maker, etc. from the DB row. With PreserveFrom, the row
+// retains its previously-stored values.
+func TestGetMovieInfo_EmptyFieldsDoNotClobberExisting(t *testing.T) {
+	e := newTestEngine(t)
+	p := newFakeMovieProvider("FakeProvider")
+
+	id := "sone00052"
+
+	// --- Step 1: fully-populated fetch.
+	full := fullMovieInfo(id, p.name)
+	p.next = full
+	got1, err := e.getMovieInfoByProviderID(p, id, false /* lazy */)
+	if err != nil {
+		t.Fatalf("first fetch failed: %v", err)
+	}
+	if got1.Summary != full.Summary {
+		t.Fatalf("step 1: returned info should have full Summary, got %q", got1.Summary)
+	}
+
+	// Verify DB now has the full info.
+	stored, err := e.getMovieInfoFromDB(p, id)
+	if err != nil {
+		t.Fatalf("DB read after step 1: %v", err)
+	}
+	if stored.Summary != full.Summary {
+		t.Fatalf("step 1: DB Summary mismatch, got %q want %q", stored.Summary, full.Summary)
+	}
+	if len(stored.Actors) != 2 {
+		t.Fatalf("step 1: DB Actors mismatch, got %v", stored.Actors)
+	}
+
+	// --- Step 2: provider returns minimal info (the bug trigger).
+	p.next = minimalMovieInfo(id, p.name)
+	got2, err := e.getMovieInfoByProviderID(p, id, false /* lazy */)
+	if err != nil {
+		t.Fatalf("second fetch failed: %v", err)
+	}
+
+	// The returned struct should also be enriched - PreserveFrom mutates the
+	// info before upsert, so callers see the merged result.
+	if got2.Summary != full.Summary {
+		t.Errorf("step 2: returned Summary should be preserved, got %q want %q",
+			got2.Summary, full.Summary)
+	}
+
+	// Re-read from DB to confirm persistence.
+	stored2, err := e.getMovieInfoFromDB(p, id)
+	if err != nil {
+		t.Fatalf("DB read after step 2: %v", err)
+	}
+	if stored2.Summary != full.Summary {
+		t.Errorf("step 2: DB Summary was clobbered, got %q want %q",
+			stored2.Summary, full.Summary)
+	}
+	if stored2.Director != full.Director {
+		t.Errorf("step 2: DB Director was clobbered, got %q want %q",
+			stored2.Director, full.Director)
+	}
+	if len(stored2.Actors) != len(full.Actors) {
+		t.Errorf("step 2: DB Actors was clobbered, got %v want %v",
+			stored2.Actors, full.Actors)
+	}
+	if len(stored2.Genres) != len(full.Genres) {
+		t.Errorf("step 2: DB Genres was clobbered, got %v want %v",
+			stored2.Genres, full.Genres)
+	}
+	if stored2.Score != full.Score {
+		t.Errorf("step 2: DB Score was clobbered, got %v want %v", stored2.Score, full.Score)
+	}
+	if stored2.Maker != full.Maker {
+		t.Errorf("step 2: DB Maker was clobbered, got %q want %q", stored2.Maker, full.Maker)
+	}
+	if stored2.Label != full.Label {
+		t.Errorf("step 2: DB Label was clobbered, got %q want %q", stored2.Label, full.Label)
+	}
+	if stored2.Series != full.Series {
+		t.Errorf("step 2: DB Series was clobbered, got %q want %q", stored2.Series, full.Series)
+	}
+}
+
+// TestGetMovieInfo_NonEmptyFieldsWinOverExisting verifies the converse: when
+// the provider DOES return a non-empty value, it should overwrite the DB. We
+// must not regress into a "DB always wins" model where providers can never
+// update their own data.
+func TestGetMovieInfo_NonEmptyFieldsWinOverExisting(t *testing.T) {
+	e := newTestEngine(t)
+	p := newFakeMovieProvider("FakeProvider")
+
+	id := "id-1"
+
+	// Seed DB with a v1 of the movie.
+	p.next = fullMovieInfo(id, p.name)
+	if _, err := e.getMovieInfoByProviderID(p, id, false); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Provider now returns a v2 with updated Summary, Score, and an extra actor.
+	v2 := fullMovieInfo(id, p.name)
+	v2.Summary = "Updated summary - v2."
+	v2.Score = 4.9
+	v2.Actors = pq.StringArray{"new-actor"}
+	v2.Genres = pq.StringArray{"new-genre"}
+	p.next = v2
+	if _, err := e.getMovieInfoByProviderID(p, id, false); err != nil {
+		t.Fatalf("v2 fetch: %v", err)
+	}
+
+	stored, err := e.getMovieInfoFromDB(p, id)
+	if err != nil {
+		t.Fatalf("DB read: %v", err)
+	}
+	if stored.Summary != "Updated summary - v2." {
+		t.Errorf("Summary v2 should win, got %q", stored.Summary)
+	}
+	if stored.Score != 4.9 {
+		t.Errorf("Score v2 should win, got %v", stored.Score)
+	}
+	// Actors should be replaced (not appended).
+	if len(stored.Actors) != 1 || stored.Actors[0] != "new-actor" {
+		t.Errorf("Actors v2 should replace v1, got %v", stored.Actors)
+	}
+	if len(stored.Genres) != 1 || stored.Genres[0] != "new-genre" {
+		t.Errorf("Genres v2 should replace v1, got %v", stored.Genres)
+	}
+}
+
+// TestGetMovieInfo_LazyHitDoesNotTriggerUpsert verifies that the lazy path
+// (DB hit on a valid record) returns early WITHOUT touching the DB. This is
+// important because the auto-save defer is registered AFTER the lazy check;
+// our PreserveFrom logic lives inside that defer and must not fire on lazy
+// DB hits.
+func TestGetMovieInfo_LazyHitDoesNotTriggerUpsert(t *testing.T) {
+	e := newTestEngine(t)
+	p := newFakeMovieProvider("FakeProvider")
+
+	id := "id-1"
+
+	// Seed.
+	p.next = fullMovieInfo(id, p.name)
+	if _, err := e.getMovieInfoByProviderID(p, id, false); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Configure the provider to fail loudly if called - lazy hit should
+	// short-circuit and never invoke the provider callback.
+	called := false
+	p.next = nil
+	p.err = nil
+	wrappedProvider := &countingProvider{fakeMovieProvider: p, callCount: &called}
+
+	got, err := e.getMovieInfoByProviderID(wrappedProvider, id, true /* lazy */)
+	if err != nil {
+		t.Fatalf("lazy fetch: %v", err)
+	}
+	if called {
+		t.Errorf("lazy hit should not invoke provider, but GetMovieInfoByID was called")
+	}
+	if got.Summary != "Full summary, the good one." {
+		t.Errorf("lazy hit should return DB record, got Summary=%q", got.Summary)
+	}
+}
+
+// countingProvider wraps fakeMovieProvider and flips a flag when
+// GetMovieInfoByID is called.
+type countingProvider struct {
+	*fakeMovieProvider
+	callCount *bool
+}
+
+func (c *countingProvider) GetMovieInfoByID(id string) (*model.MovieInfo, error) {
+	*c.callCount = true
+	return c.fakeMovieProvider.GetMovieInfoByID(id)
+}
+
+// TestGetMovieInfo_FreshInsertWorks verifies the baseline: a first-time fetch
+// with no existing DB record stores the full info verbatim. PreserveFrom must
+// be a no-op when there's nothing to preserve from.
+func TestGetMovieInfo_FreshInsertWorks(t *testing.T) {
+	e := newTestEngine(t)
+	p := newFakeMovieProvider("FakeProvider")
+
+	id := "brand-new"
+	p.next = fullMovieInfo(id, p.name)
+
+	got, err := e.getMovieInfoByProviderID(p, id, false)
+	if err != nil {
+		t.Fatalf("fresh insert: %v", err)
+	}
+	if got.Summary != p.next.Summary {
+		t.Errorf("Summary mismatch, got %q want %q", got.Summary, p.next.Summary)
+	}
+
+	stored, err := e.getMovieInfoFromDB(p, id)
+	if err != nil {
+		t.Fatalf("DB read: %v", err)
+	}
+	if stored.Summary != p.next.Summary {
+		t.Errorf("DB Summary mismatch, got %q want %q", stored.Summary, p.next.Summary)
+	}
+	if len(stored.Actors) != 2 {
+		t.Errorf("DB Actors mismatch, got %v", stored.Actors)
+	}
+}

--- a/engine/movie.go
+++ b/engine/movie.go
@@ -223,6 +223,13 @@ func (e *Engine) getMovieInfoWithCallback(provider mt.MovieProvider, id string, 
 	// delayed info auto-save.
 	defer func() {
 		if err == nil && info.IsValid() {
+			// Preserve any non-empty fields from the existing DB record, so a
+			// fresh fetch that returned empty optional fields doesn't clobber
+			// previously-stored good data. IsValid() already guarantees the
+			// required (primary key) fields are populated on info.
+			if existing, dbErr := e.getMovieInfoFromDB(provider, id); dbErr == nil {
+				info.PreserveFrom(existing)
+			}
 			e.db.Clauses(clause.OnConflict{
 				UpdateAll: true,
 			}).Create(info) // ignore error

--- a/model/actor.go
+++ b/model/actor.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"time"
+
 	"github.com/lib/pq"
 	"gorm.io/datatypes"
 )
@@ -63,5 +65,65 @@ func (a *ActorInfo) ToSearchResult() *ActorSearchResult {
 		Homepage: a.Homepage,
 		Aliases:  a.Aliases,
 		Images:   a.Images,
+	}
+}
+
+// PreserveFrom fills in zero-value fields of a using non-zero values from
+// existing. It implements "non-empty wins" semantics: if a has a non-zero
+// value for a field, a keeps it; if a has the zero value for a field, a takes
+// existing's value.
+//
+// This is meant to be called immediately before upserting a freshly-fetched
+// ActorInfo, so that a provider response with missing optional fields does
+// not clobber previously-stored good data when GORM's clause.OnConflict
+// {UpdateAll: true} writes every column.
+//
+// Required (IsValid) fields - ID, Name, Provider, Homepage - are NOT touched:
+// IsValid() gates the call and guarantees a has them all populated.
+// TimeTracker fields (CreatedAt, UpdatedAt) are managed by GORM and likewise
+// not touched here.
+func (a *ActorInfo) PreserveFrom(existing *ActorInfo) {
+	if existing == nil {
+		return
+	}
+	// Optional string fields.
+	if a.Summary == "" {
+		a.Summary = existing.Summary
+	}
+	if a.Hobby == "" {
+		a.Hobby = existing.Hobby
+	}
+	if a.Skill == "" {
+		a.Skill = existing.Skill
+	}
+	if a.BloodType == "" {
+		a.BloodType = existing.BloodType
+	}
+	if a.CupSize == "" {
+		a.CupSize = existing.CupSize
+	}
+	if a.Measurements == "" {
+		a.Measurements = existing.Measurements
+	}
+	if a.Nationality == "" {
+		a.Nationality = existing.Nationality
+	}
+	// Numeric field.
+	if a.Height == 0 {
+		a.Height = existing.Height
+	}
+	// Array fields (pq.StringArray).
+	if len(a.Aliases) == 0 {
+		a.Aliases = existing.Aliases
+	}
+	if len(a.Images) == 0 {
+		a.Images = existing.Images
+	}
+	// Date fields.
+	if time.Time(a.Birthday).IsZero() {
+		a.Birthday = existing.Birthday
+	}
+	if time.Time(a.DebutDate).IsZero() {
+		a.DebutDate = existing.DebutDate
 	}
 }

--- a/model/actor_test.go
+++ b/model/actor_test.go
@@ -1,0 +1,204 @@
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+	"gorm.io/datatypes"
+)
+
+func TestActorInfo_IsValid(t *testing.T) {
+	t.Parallel()
+
+	base := ActorInfo{
+		ID:       "a1",
+		Name:     "Alice",
+		Provider: "Test",
+		Homepage: "https://example.com/a1",
+	}
+	if !base.IsValid() {
+		t.Fatalf("baseline ActorInfo should be valid, got invalid: %+v", base)
+	}
+
+	withoutSummary := base
+	withoutSummary.Summary = ""
+	if !withoutSummary.IsValid() {
+		t.Errorf("ActorInfo with empty Summary should still be valid (Summary is optional)")
+	}
+
+	for _, tc := range []struct {
+		name string
+		mut  func(*ActorInfo)
+	}{
+		{"missing ID", func(a *ActorInfo) { a.ID = "" }},
+		{"missing Name", func(a *ActorInfo) { a.Name = "" }},
+		{"missing Provider", func(a *ActorInfo) { a.Provider = "" }},
+		{"missing Homepage", func(a *ActorInfo) { a.Homepage = "" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := base
+			tc.mut(&a)
+			if a.IsValid() {
+				t.Errorf("ActorInfo missing required field should be invalid: %+v", a)
+			}
+		})
+	}
+}
+
+func TestActorInfo_PreserveFrom_NilExisting(t *testing.T) {
+	t.Parallel()
+	a := &ActorInfo{ID: "a1"}
+	a.PreserveFrom(nil)
+	if a.ID != "a1" {
+		t.Errorf("PreserveFrom(nil) should not touch any field, got ID=%q", a.ID)
+	}
+}
+
+func fullExistingActor() *ActorInfo {
+	return &ActorInfo{
+		ID:           "a1",
+		Name:         "Existing Alice",
+		Provider:     "TestProvider",
+		Homepage:     "https://example.com/a1",
+		Summary:      "Existing bio.",
+		Hobby:        "Existing hobby",
+		Skill:        "Existing skill",
+		BloodType:    "A",
+		CupSize:      "C",
+		Measurements: "B85-W58-H86",
+		Nationality:  "Japan",
+		Height:       165,
+		Aliases:      pq.StringArray{"alias1", "alias2"},
+		Images:       pq.StringArray{"https://example.com/img1.jpg"},
+		Birthday:     datatypes.Date(time.Date(1995, 1, 1, 0, 0, 0, 0, time.UTC)),
+		DebutDate:    datatypes.Date(time.Date(2015, 6, 1, 0, 0, 0, 0, time.UTC)),
+	}
+}
+
+func TestActorInfo_PreserveFrom_EmptyFreshKeepsAllExisting(t *testing.T) {
+	t.Parallel()
+	fresh := &ActorInfo{
+		ID:       "a1",
+		Name:     "Existing Alice",
+		Provider: "TestProvider",
+		Homepage: "https://example.com/a1",
+	}
+	existing := fullExistingActor()
+
+	fresh.PreserveFrom(existing)
+
+	if fresh.Summary != existing.Summary {
+		t.Errorf("Summary should be preserved, got %q", fresh.Summary)
+	}
+	if fresh.Hobby != existing.Hobby {
+		t.Errorf("Hobby should be preserved, got %q", fresh.Hobby)
+	}
+	if fresh.Skill != existing.Skill {
+		t.Errorf("Skill should be preserved, got %q", fresh.Skill)
+	}
+	if fresh.BloodType != existing.BloodType {
+		t.Errorf("BloodType should be preserved, got %q", fresh.BloodType)
+	}
+	if fresh.CupSize != existing.CupSize {
+		t.Errorf("CupSize should be preserved, got %q", fresh.CupSize)
+	}
+	if fresh.Measurements != existing.Measurements {
+		t.Errorf("Measurements should be preserved, got %q", fresh.Measurements)
+	}
+	if fresh.Nationality != existing.Nationality {
+		t.Errorf("Nationality should be preserved, got %q", fresh.Nationality)
+	}
+	if fresh.Height != existing.Height {
+		t.Errorf("Height should be preserved, got %d", fresh.Height)
+	}
+	if len(fresh.Aliases) != len(existing.Aliases) {
+		t.Errorf("Aliases should be preserved, got %v", fresh.Aliases)
+	}
+	if len(fresh.Images) != len(existing.Images) {
+		t.Errorf("Images should be preserved, got %v", fresh.Images)
+	}
+	if time.Time(fresh.Birthday) != time.Time(existing.Birthday) {
+		t.Errorf("Birthday should be preserved, got %v", time.Time(fresh.Birthday))
+	}
+	if time.Time(fresh.DebutDate) != time.Time(existing.DebutDate) {
+		t.Errorf("DebutDate should be preserved, got %v", time.Time(fresh.DebutDate))
+	}
+}
+
+func TestActorInfo_PreserveFrom_NonEmptyFreshWinsOverExisting(t *testing.T) {
+	t.Parallel()
+	fresh := &ActorInfo{
+		ID:           "a1",
+		Name:         "Fresh Alice",
+		Provider:     "TestProvider",
+		Homepage:     "https://example.com/a1",
+		Summary:      "Fresh bio.",
+		Hobby:        "Fresh hobby",
+		Skill:        "Fresh skill",
+		BloodType:    "O",
+		CupSize:      "D",
+		Measurements: "B90-W60-H88",
+		Nationality:  "Korea",
+		Height:       170,
+		Aliases:      pq.StringArray{"fresh-alias"},
+		Images:       pq.StringArray{"https://fresh.example.com/img.jpg"},
+		Birthday:     datatypes.Date(time.Date(1996, 2, 2, 0, 0, 0, 0, time.UTC)),
+		DebutDate:    datatypes.Date(time.Date(2016, 7, 2, 0, 0, 0, 0, time.UTC)),
+	}
+	existing := fullExistingActor()
+	want := *fresh
+
+	fresh.PreserveFrom(existing)
+
+	if fresh.Summary != want.Summary {
+		t.Errorf("Summary: fresh should win, got %q", fresh.Summary)
+	}
+	if fresh.BloodType != want.BloodType {
+		t.Errorf("BloodType: fresh should win, got %q", fresh.BloodType)
+	}
+	if fresh.Height != want.Height {
+		t.Errorf("Height: fresh should win, got %d", fresh.Height)
+	}
+	if len(fresh.Aliases) != 1 || fresh.Aliases[0] != "fresh-alias" {
+		t.Errorf("Aliases: fresh should win (no merge), got %v", fresh.Aliases)
+	}
+	if time.Time(fresh.Birthday) != time.Time(want.Birthday) {
+		t.Errorf("Birthday: fresh should win, got %v", time.Time(fresh.Birthday))
+	}
+}
+
+func TestActorInfo_PreserveFrom_RequiredFieldsNeverTouched(t *testing.T) {
+	t.Parallel()
+	fresh := &ActorInfo{
+		ID:       "fresh-id",
+		Name:     "Fresh Name",
+		Provider: "FreshProvider",
+		Homepage: "https://fresh.example.com/id",
+	}
+	existing := &ActorInfo{
+		ID:       "stale-id",
+		Name:     "Stale Name",
+		Provider: "StaleProvider",
+		Homepage: "https://stale.example.com/id",
+		Summary:  "stale bio",
+	}
+
+	fresh.PreserveFrom(existing)
+
+	if fresh.ID != "fresh-id" {
+		t.Errorf("ID should NEVER be replaced, got %q", fresh.ID)
+	}
+	if fresh.Name != "Fresh Name" {
+		t.Errorf("Name should NEVER be replaced, got %q", fresh.Name)
+	}
+	if fresh.Provider != "FreshProvider" {
+		t.Errorf("Provider should NEVER be replaced, got %q", fresh.Provider)
+	}
+	if fresh.Homepage != "https://fresh.example.com/id" {
+		t.Errorf("Homepage should NEVER be replaced, got %q", fresh.Homepage)
+	}
+	if fresh.Summary != "stale bio" {
+		t.Errorf("Summary (optional) should be preserved, got %q", fresh.Summary)
+	}
+}

--- a/model/movie.go
+++ b/model/movie.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"time"
+
 	"github.com/lib/pq"
 	"gorm.io/datatypes"
 )
@@ -124,5 +126,79 @@ func (m *MovieInfo) ToSearchResult() *MovieSearchResult {
 		Score:       m.Score,
 		Actors:      m.Actors,
 		ReleaseDate: m.ReleaseDate,
+	}
+}
+
+// PreserveFrom fills in zero-value fields of m using non-zero values from
+// existing. It implements "non-empty wins" semantics: if m has a non-zero
+// value for a field, m keeps it; if m has the zero value for a field, m takes
+// existing's value.
+//
+// This is meant to be called immediately before upserting a freshly-fetched
+// MovieInfo, so that a provider response with missing optional fields does
+// not clobber previously-stored good data when GORM's clause.OnConflict
+// {UpdateAll: true} writes every column.
+//
+// Required (IsValid) fields - ID, Number, Title, CoverURL, Provider, Homepage -
+// are NOT touched: IsValid() gates the call and guarantees m has them all
+// populated, and the primary key columns (ID, Provider) must come from m anyway.
+// TimeTracker fields (CreatedAt, UpdatedAt) are NOT touched either: GORM
+// manages them automatically via AutoCreateTime / AutoUpdateTime, and they
+// are special-cased out of the OnConflict update.
+func (m *MovieInfo) PreserveFrom(existing *MovieInfo) {
+	if existing == nil {
+		return
+	}
+	// Optional string fields.
+	if m.Summary == "" {
+		m.Summary = existing.Summary
+	}
+	if m.Director == "" {
+		m.Director = existing.Director
+	}
+	if m.ThumbURL == "" {
+		m.ThumbURL = existing.ThumbURL
+	}
+	if m.BigThumbURL == "" {
+		m.BigThumbURL = existing.BigThumbURL
+	}
+	if m.BigCoverURL == "" {
+		m.BigCoverURL = existing.BigCoverURL
+	}
+	if m.PreviewVideoURL == "" {
+		m.PreviewVideoURL = existing.PreviewVideoURL
+	}
+	if m.PreviewVideoHLSURL == "" {
+		m.PreviewVideoHLSURL = existing.PreviewVideoHLSURL
+	}
+	if m.Maker == "" {
+		m.Maker = existing.Maker
+	}
+	if m.Label == "" {
+		m.Label = existing.Label
+	}
+	if m.Series == "" {
+		m.Series = existing.Series
+	}
+	// Array fields (pq.StringArray).
+	if len(m.Actors) == 0 {
+		m.Actors = existing.Actors
+	}
+	if len(m.PreviewImages) == 0 {
+		m.PreviewImages = existing.PreviewImages
+	}
+	if len(m.Genres) == 0 {
+		m.Genres = existing.Genres
+	}
+	// Numeric fields.
+	if m.Score == 0 {
+		m.Score = existing.Score
+	}
+	if m.Runtime == 0 {
+		m.Runtime = existing.Runtime
+	}
+	// Date field.
+	if time.Time(m.ReleaseDate).IsZero() {
+		m.ReleaseDate = existing.ReleaseDate
 	}
 }

--- a/model/movie_test.go
+++ b/model/movie_test.go
@@ -1,0 +1,341 @@
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+	"gorm.io/datatypes"
+)
+
+func TestMovieInfo_IsValid(t *testing.T) {
+	// Lock current IsValid semantics: Summary is NOT required.
+	// PreserveFrom relies on this invariant - changing IsValid to require
+	// Summary would break providers (e.g. JavBus) that never set it.
+	t.Parallel()
+
+	base := MovieInfo{
+		ID:       "abc",
+		Number:   "ABC-001",
+		Title:    "Title",
+		CoverURL: "https://example.com/cover.jpg",
+		Provider: "Test",
+		Homepage: "https://example.com/abc",
+	}
+	if !base.IsValid() {
+		t.Fatalf("baseline MovieInfo should be valid, got invalid: %+v", base)
+	}
+
+	withoutSummary := base
+	withoutSummary.Summary = ""
+	if !withoutSummary.IsValid() {
+		t.Errorf("MovieInfo with empty Summary should still be valid (Summary is optional)")
+	}
+
+	for _, tc := range []struct {
+		name string
+		mut  func(*MovieInfo)
+	}{
+		{"missing ID", func(m *MovieInfo) { m.ID = "" }},
+		{"missing Number", func(m *MovieInfo) { m.Number = "" }},
+		{"missing Title", func(m *MovieInfo) { m.Title = "" }},
+		{"missing CoverURL", func(m *MovieInfo) { m.CoverURL = "" }},
+		{"missing Provider", func(m *MovieInfo) { m.Provider = "" }},
+		{"missing Homepage", func(m *MovieInfo) { m.Homepage = "" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := base
+			tc.mut(&m)
+			if m.IsValid() {
+				t.Errorf("MovieInfo missing required field should be invalid: %+v", m)
+			}
+		})
+	}
+}
+
+func TestMovieInfo_PreserveFrom_NilExisting(t *testing.T) {
+	t.Parallel()
+	m := &MovieInfo{ID: "abc"}
+	// Must not panic, must not mutate.
+	m.PreserveFrom(nil)
+	if m.ID != "abc" {
+		t.Errorf("PreserveFrom(nil) should not touch any field, got ID=%q", m.ID)
+	}
+}
+
+// fullExisting returns an existing MovieInfo with every optional field populated.
+// Used as the "previously stored good data" baseline for clobber-prevention tests.
+func fullExisting() *MovieInfo {
+	return &MovieInfo{
+		ID:                 "id-1",
+		Number:             "NUM-001",
+		Title:              "Existing Title",
+		Summary:            "Existing summary, the good one.",
+		Provider:           "TestProvider",
+		Homepage:           "https://example.com/id-1",
+		Director:           "Existing Director",
+		Actors:             pq.StringArray{"actor1", "actor2"},
+		ThumbURL:           "https://example.com/thumb.jpg",
+		BigThumbURL:        "https://example.com/big-thumb.jpg",
+		CoverURL:           "https://example.com/cover.jpg",
+		BigCoverURL:        "https://example.com/big-cover.jpg",
+		PreviewVideoURL:    "https://example.com/preview.mp4",
+		PreviewVideoHLSURL: "https://example.com/preview.m3u8",
+		PreviewImages:      pq.StringArray{"https://example.com/p1.jpg"},
+		Maker:              "Existing Maker",
+		Label:              "Existing Label",
+		Series:             "Existing Series",
+		Genres:             pq.StringArray{"genre1", "genre2"},
+		Score:              4.5,
+		Runtime:            120,
+		ReleaseDate:        datatypes.Date(time.Date(2024, 2, 13, 0, 0, 0, 0, time.UTC)),
+	}
+}
+
+func TestMovieInfo_PreserveFrom_EmptyFreshKeepsAllExisting(t *testing.T) {
+	t.Parallel()
+	// Simulates the bug case: a fresh fetch returned all-empty optional
+	// fields but the required (IsValid) fields are populated. Without
+	// PreserveFrom, this would clobber the DB. With PreserveFrom, all the
+	// optional fields are restored from `existing`.
+	fresh := &MovieInfo{
+		ID:       "id-1",
+		Number:   "NUM-001",
+		Title:    "Existing Title",
+		CoverURL: "https://example.com/cover.jpg",
+		Provider: "TestProvider",
+		Homepage: "https://example.com/id-1",
+	}
+	existing := fullExisting()
+
+	fresh.PreserveFrom(existing)
+
+	if fresh.Summary != existing.Summary {
+		t.Errorf("Summary should be preserved from existing, got %q want %q", fresh.Summary, existing.Summary)
+	}
+	if fresh.Director != existing.Director {
+		t.Errorf("Director should be preserved, got %q", fresh.Director)
+	}
+	if fresh.ThumbURL != existing.ThumbURL {
+		t.Errorf("ThumbURL should be preserved, got %q", fresh.ThumbURL)
+	}
+	if fresh.BigThumbURL != existing.BigThumbURL {
+		t.Errorf("BigThumbURL should be preserved, got %q", fresh.BigThumbURL)
+	}
+	if fresh.BigCoverURL != existing.BigCoverURL {
+		t.Errorf("BigCoverURL should be preserved, got %q", fresh.BigCoverURL)
+	}
+	if fresh.PreviewVideoURL != existing.PreviewVideoURL {
+		t.Errorf("PreviewVideoURL should be preserved, got %q", fresh.PreviewVideoURL)
+	}
+	if fresh.PreviewVideoHLSURL != existing.PreviewVideoHLSURL {
+		t.Errorf("PreviewVideoHLSURL should be preserved, got %q", fresh.PreviewVideoHLSURL)
+	}
+	if fresh.Maker != existing.Maker {
+		t.Errorf("Maker should be preserved, got %q", fresh.Maker)
+	}
+	if fresh.Label != existing.Label {
+		t.Errorf("Label should be preserved, got %q", fresh.Label)
+	}
+	if fresh.Series != existing.Series {
+		t.Errorf("Series should be preserved, got %q", fresh.Series)
+	}
+	if len(fresh.Actors) != len(existing.Actors) {
+		t.Errorf("Actors should be preserved, got %v", fresh.Actors)
+	}
+	if len(fresh.PreviewImages) != len(existing.PreviewImages) {
+		t.Errorf("PreviewImages should be preserved, got %v", fresh.PreviewImages)
+	}
+	if len(fresh.Genres) != len(existing.Genres) {
+		t.Errorf("Genres should be preserved, got %v", fresh.Genres)
+	}
+	if fresh.Score != existing.Score {
+		t.Errorf("Score should be preserved, got %v", fresh.Score)
+	}
+	if fresh.Runtime != existing.Runtime {
+		t.Errorf("Runtime should be preserved, got %v", fresh.Runtime)
+	}
+	if time.Time(fresh.ReleaseDate) != time.Time(existing.ReleaseDate) {
+		t.Errorf("ReleaseDate should be preserved, got %v", time.Time(fresh.ReleaseDate))
+	}
+}
+
+func TestMovieInfo_PreserveFrom_NonEmptyFreshWinsOverExisting(t *testing.T) {
+	t.Parallel()
+	// "Non-empty wins" semantics: if the fresh fetch has a value, it must
+	// override the existing DB value (provider has authority over its own data).
+	fresh := &MovieInfo{
+		ID:                 "id-1",
+		Number:             "NUM-001",
+		Title:              "Fresh Title",
+		Summary:            "Fresh summary, brand new.",
+		CoverURL:           "https://fresh.example.com/cover.jpg",
+		Provider:           "TestProvider",
+		Homepage:           "https://example.com/id-1",
+		Director:           "Fresh Director",
+		Actors:             pq.StringArray{"fresh-actor"},
+		ThumbURL:           "https://fresh.example.com/thumb.jpg",
+		BigThumbURL:        "https://fresh.example.com/big-thumb.jpg",
+		BigCoverURL:        "https://fresh.example.com/big-cover.jpg",
+		PreviewVideoURL:    "https://fresh.example.com/preview.mp4",
+		PreviewVideoHLSURL: "https://fresh.example.com/preview.m3u8",
+		PreviewImages:      pq.StringArray{"https://fresh.example.com/p1.jpg"},
+		Maker:              "Fresh Maker",
+		Label:              "Fresh Label",
+		Series:             "Fresh Series",
+		Genres:             pq.StringArray{"fresh-genre"},
+		Score:              3.0,
+		Runtime:            90,
+		ReleaseDate:        datatypes.Date(time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)),
+	}
+	existing := fullExisting()
+	want := *fresh // snapshot before PreserveFrom
+
+	fresh.PreserveFrom(existing)
+
+	if fresh.Summary != want.Summary {
+		t.Errorf("Summary: fresh should win, got %q want %q", fresh.Summary, want.Summary)
+	}
+	if fresh.Director != want.Director {
+		t.Errorf("Director: fresh should win, got %q want %q", fresh.Director, want.Director)
+	}
+	if fresh.ThumbURL != want.ThumbURL {
+		t.Errorf("ThumbURL: fresh should win, got %q", fresh.ThumbURL)
+	}
+	if fresh.Maker != want.Maker {
+		t.Errorf("Maker: fresh should win, got %q", fresh.Maker)
+	}
+	if len(fresh.Actors) != 1 || fresh.Actors[0] != "fresh-actor" {
+		t.Errorf("Actors: fresh should win (no merge/append), got %v", fresh.Actors)
+	}
+	if fresh.Score != 3.0 {
+		t.Errorf("Score: fresh should win, got %v", fresh.Score)
+	}
+	if fresh.Runtime != 90 {
+		t.Errorf("Runtime: fresh should win, got %v", fresh.Runtime)
+	}
+	if time.Time(fresh.ReleaseDate) != time.Time(want.ReleaseDate) {
+		t.Errorf("ReleaseDate: fresh should win, got %v", time.Time(fresh.ReleaseDate))
+	}
+}
+
+func TestMovieInfo_PreserveFrom_MixedFields(t *testing.T) {
+	t.Parallel()
+	// Real-world case: fresh has *some* fields (e.g. it got Title and Summary
+	// but missed Director and Genres). Only the empty ones should be filled
+	// from existing.
+	fresh := &MovieInfo{
+		ID:       "id-1",
+		Number:   "NUM-001",
+		Title:    "Fresh Title",
+		Summary:  "Fresh summary kept.",
+		CoverURL: "https://fresh.example.com/cover.jpg",
+		Provider: "TestProvider",
+		Homepage: "https://example.com/id-1",
+		// Director, Genres, Score, Runtime, ReleaseDate intentionally empty.
+		Actors: pq.StringArray{"fresh-actor"},
+	}
+	existing := fullExisting()
+
+	fresh.PreserveFrom(existing)
+
+	// Fresh-set fields should remain unchanged.
+	if fresh.Summary != "Fresh summary kept." {
+		t.Errorf("Summary was unexpectedly overwritten, got %q", fresh.Summary)
+	}
+	if len(fresh.Actors) != 1 || fresh.Actors[0] != "fresh-actor" {
+		t.Errorf("Actors was unexpectedly overwritten, got %v", fresh.Actors)
+	}
+
+	// Empty fields should be filled from existing.
+	if fresh.Director != existing.Director {
+		t.Errorf("Director should be preserved, got %q", fresh.Director)
+	}
+	if len(fresh.Genres) != len(existing.Genres) {
+		t.Errorf("Genres should be preserved, got %v", fresh.Genres)
+	}
+	if fresh.Score != existing.Score {
+		t.Errorf("Score should be preserved, got %v", fresh.Score)
+	}
+	if fresh.Runtime != existing.Runtime {
+		t.Errorf("Runtime should be preserved, got %v", fresh.Runtime)
+	}
+	if time.Time(fresh.ReleaseDate) != time.Time(existing.ReleaseDate) {
+		t.Errorf("ReleaseDate should be preserved, got %v", time.Time(fresh.ReleaseDate))
+	}
+}
+
+func TestMovieInfo_PreserveFrom_RequiredFieldsNeverTouched(t *testing.T) {
+	t.Parallel()
+	// Even if existing differs on a required (IsValid) field, PreserveFrom
+	// must leave m's required fields alone. The fresh fetch is authoritative
+	// for ID/Number/Title/CoverURL/Provider/Homepage.
+	fresh := &MovieInfo{
+		ID:       "fresh-id",
+		Number:   "FRESH-001",
+		Title:    "Fresh Title",
+		CoverURL: "https://fresh.example.com/cover.jpg",
+		Provider: "FreshProvider",
+		Homepage: "https://fresh.example.com/id",
+	}
+	existing := &MovieInfo{
+		ID:       "stale-id",
+		Number:   "STALE-001",
+		Title:    "Stale Title",
+		CoverURL: "https://stale.example.com/cover.jpg",
+		Provider: "StaleProvider",
+		Homepage: "https://stale.example.com/id",
+		Summary:  "stale summary",
+	}
+
+	fresh.PreserveFrom(existing)
+
+	if fresh.ID != "fresh-id" {
+		t.Errorf("ID should NEVER be replaced, got %q", fresh.ID)
+	}
+	if fresh.Number != "FRESH-001" {
+		t.Errorf("Number should NEVER be replaced, got %q", fresh.Number)
+	}
+	if fresh.Title != "Fresh Title" {
+		t.Errorf("Title should NEVER be replaced, got %q", fresh.Title)
+	}
+	if fresh.CoverURL != "https://fresh.example.com/cover.jpg" {
+		t.Errorf("CoverURL should NEVER be replaced, got %q", fresh.CoverURL)
+	}
+	if fresh.Provider != "FreshProvider" {
+		t.Errorf("Provider should NEVER be replaced, got %q", fresh.Provider)
+	}
+	if fresh.Homepage != "https://fresh.example.com/id" {
+		t.Errorf("Homepage should NEVER be replaced, got %q", fresh.Homepage)
+	}
+	// Optional field: should still flow from existing.
+	if fresh.Summary != "stale summary" {
+		t.Errorf("Summary (optional) should be preserved from existing, got %q", fresh.Summary)
+	}
+}
+
+func TestMovieInfo_PreserveFrom_EmptyArrayPreservesExisting(t *testing.T) {
+	t.Parallel()
+	// Edge case: nil vs empty slice. Both must be treated as "no value" so
+	// the existing array is kept.
+	for _, tc := range []struct {
+		name   string
+		actors pq.StringArray
+	}{
+		{"nil slice", nil},
+		{"empty slice", pq.StringArray{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fresh := &MovieInfo{
+				ID: "id-1", Number: "NUM-001", Title: "T",
+				CoverURL: "c", Provider: "P", Homepage: "h",
+				Actors: tc.actors,
+			}
+			existing := fullExisting()
+			fresh.PreserveFrom(existing)
+			if len(fresh.Actors) != len(existing.Actors) {
+				t.Errorf("Actors should be preserved when fresh is %s, got %v", tc.name, fresh.Actors)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

When a provider re-fetches a movie/actor and returns a record that passes `IsValid()` but leaves some optional fields empty (e.g. JavBus never setting `Summary`, JAV321 hitting a transient 404, or a provider that omits `Director`/`Maker`/`Score`/`Actors`), the deferred upsert in `engine/movie.go` and `engine/actor.go` uses `clause.OnConflict{UpdateAll: true}` and **silently clobbers the previously-stored good values with empty strings / zero values**. Once overwritten, even subsequent `lazy=true` requests return the now-empty record from the DB.

This PR fixes the clobber by introducing *"non-empty wins"* upsert semantics:

- `model.MovieInfo.PreserveFrom(existing)` and `model.ActorInfo.PreserveFrom(existing)` — for every optional field, if the fresh fetch has a zero value, take the value from the existing DB row; otherwise keep the fresh value.
- Fields used by `IsValid()` (required identifiers, provider, etc.) are **never** touched — they always come from the provider.
- The auto-save defers in `getMovieInfoWithCallback` / `getActorInfoWithCallback` now read the existing row and call `PreserveFrom` before invoking the upsert.

The review flow (`engine/review.go`) is intentionally left alone: reviews are replaced wholesale and have no per-field clobber surface.

## What's covered

- `model/movie.go`, `model/actor.go` — add `PreserveFrom` (all optional fields, including slices, time, decimals).
- `engine/movie.go`, `engine/actor.go` — read existing row → `PreserveFrom` → upsert.
- `model/movie_test.go`, `model/actor_test.go` — unit tests for `PreserveFrom` semantics (empty stays empty, non-empty preserved, fresh wins when both set, required fields untouched).
- `engine/engine_persist_test.go`, `engine/engine_persist_actor_test.go` — end-to-end SQLite tests that simulate a full fetch → minimal re-fetch and assert the DB row retains its optional fields.

## Test plan

- [x] `go test ./model/...` passes (new `PreserveFrom` unit tests).
- [x] `go test ./engine/...` passes (new SQLite persistence tests).
- [ ] CI: linter + race-enabled test workflow.
- [ ] Manual: hit a movie via a "rich" provider (e.g. one that fills `Summary` + `Director` + `Maker`), then trigger a re-fetch through a "minimal" provider for the same ID, and confirm the DB row still has the optional fields populated.

## Notes for reviewers

- `PreserveFrom` lives on the model so the rule is co-located with the schema and doesn't leak GORM into the engine.
- Behavior change is conservative: only zero-valued fields on the fresh fetch borrow from the existing row. There is no merging of slices or numerical fields beyond "did the provider give us anything?".
- No DB migration is needed.
